### PR TITLE
色情報表示エリア実装

### DIFF
--- a/src/@types/color.d.ts
+++ b/src/@types/color.d.ts
@@ -1,4 +1,4 @@
-type Color = {
+type RGB = {
   red: number;
   green: number;
   blue: number;

--- a/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.html
+++ b/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.html
@@ -1,8 +1,15 @@
 <div fxLayout="row" fxLayoutAlign="space-evenly stretch" id="container-component">
   <div fxFlex="80" class="container-component">
-    <app-image-display [class.dark-theme]="!isLight" (eventSelectRGB)="onReceiveSelectedColorEvent($event)"></app-image-display>
+    <app-image-display [class.dark-theme]="!isLight" 
+      (eventSelectRGB)="onReceiveSelectedColorEvent($event)"
+      (eventPointerRGB)="onReceivePointerColorEvent($event)">
+    </app-image-display>
   </div>
   <div fxFlex="15" class="container-component">
-    <app-picked-color [class.dark-theme]="!isLight" [setSelectedRGB]='selectedRGB'></app-picked-color>
+    <app-picked-color 
+      [class.dark-theme]="!isLight" 
+      [setSelectedRGB]='selectedRGB'
+      [setPointerRGB]='pointerRGB'>
+    </app-picked-color>
   </div>
 </div>

--- a/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.html
+++ b/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.html
@@ -1,7 +1,11 @@
-<div fxLayout="row" fxLayoutAlign="center center">
-  <div fxFlex="95">
-    <p id="click">mouse click!</p>
-    <p id="move">moouse move!</p>
+<p id="click">mouse click!</p>
+<p id="move">moouse move!</p>
+
+<div fxLayout="row" fxLayoutAlign="space-evenly stretch">
+  <div fxFlex="80" class="container-component">
     <app-image-display [class.dark-theme]="!isLight"></app-image-display>
+  </div>
+  <div fxFlex="15" class="container-component">
+    <app-picked-color [class.dark-theme]="!isLight"></app-picked-color>
   </div>
 </div>

--- a/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.html
+++ b/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.html
@@ -1,9 +1,6 @@
-<p id="click">mouse click!</p>
-<p id="move">moouse move!</p>
-
-<div fxLayout="row" fxLayoutAlign="space-evenly stretch">
+<div fxLayout="row" fxLayoutAlign="space-evenly stretch" id="container-component">
   <div fxFlex="80" class="container-component">
-    <app-image-display [class.dark-theme]="!isLight"></app-image-display>
+    <app-image-display [class.dark-theme]="!isLight" (eventSelectRGB)="onReceiveSelectedColorEvent($event)"></app-image-display>
   </div>
   <div fxFlex="15" class="container-component">
     <app-picked-color [class.dark-theme]="!isLight"></app-picked-color>

--- a/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.html
+++ b/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.html
@@ -3,6 +3,6 @@
     <app-image-display [class.dark-theme]="!isLight" (eventSelectRGB)="onReceiveSelectedColorEvent($event)"></app-image-display>
   </div>
   <div fxFlex="15" class="container-component">
-    <app-picked-color [class.dark-theme]="!isLight"></app-picked-color>
+    <app-picked-color [class.dark-theme]="!isLight" [selectedRGB]='selectedRGB'></app-picked-color>
   </div>
 </div>

--- a/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.html
+++ b/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.html
@@ -3,6 +3,6 @@
     <app-image-display [class.dark-theme]="!isLight" (eventSelectRGB)="onReceiveSelectedColorEvent($event)"></app-image-display>
   </div>
   <div fxFlex="15" class="container-component">
-    <app-picked-color [class.dark-theme]="!isLight" [selectedRGB]='selectedRGB'></app-picked-color>
+    <app-picked-color [class.dark-theme]="!isLight" [setSelectedRGB]='selectedRGB'></app-picked-color>
   </div>
 </div>

--- a/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.scss
+++ b/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.scss
@@ -1,0 +1,1 @@
+.container-component {}

--- a/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.scss
+++ b/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.scss
@@ -1,1 +1,3 @@
-.container-component {}
+.container-component {
+  margin-top: 30px;
+}

--- a/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.ts
+++ b/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.ts
@@ -10,6 +10,7 @@ import { CommonService } from '../../../../services/common.service';
 export class ImageColorPickerComponent implements OnInit, OnDestroy {
   isLight = true;
   selectedRGB = '255 255 255';
+  pointerRGB = '255 255 255';
   private subscription!: Subscription;
 
   constructor(private commonService: CommonService) {}
@@ -29,5 +30,10 @@ export class ImageColorPickerComponent implements OnInit, OnDestroy {
   onReceiveSelectedColorEvent($eventSelectRGB: RGB) {
     const rgb = $eventSelectRGB;
     this.selectedRGB = `${rgb.red} ${rgb.green} ${rgb.blue}`;
+  }
+
+  onReceivePointerColorEvent($eventPointerRGB: RGB) {
+    const rgb = $eventPointerRGB;
+    this.pointerRGB = `${rgb.red} ${rgb.green} ${rgb.blue}`;
   }
 }

--- a/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.ts
+++ b/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.ts
@@ -9,7 +9,7 @@ import { CommonService } from '../../../../services/common.service';
 })
 export class ImageColorPickerComponent implements OnInit, OnDestroy {
   isLight = true;
-  selectedRGB = '0 0 0';
+  selectedRGB = '255 255 255';
   private subscription!: Subscription;
 
   constructor(private commonService: CommonService) {}

--- a/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.ts
+++ b/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.ts
@@ -9,7 +9,7 @@ import { CommonService } from '../../../../services/common.service';
 })
 export class ImageColorPickerComponent implements OnInit, OnDestroy {
   isLight = true;
-  public selectedRGB: RGB = { red: 0, green: 0, blue: 0 };
+  selectedRGB = '0 0 0';
   private subscription!: Subscription;
 
   constructor(private commonService: CommonService) {}
@@ -27,7 +27,7 @@ export class ImageColorPickerComponent implements OnInit, OnDestroy {
   }
 
   onReceiveSelectedColorEvent($eventSelectRGB: RGB) {
-    console.log('レシーブ！');
-    this.selectedRGB = $eventSelectRGB;
+    const rgb = $eventSelectRGB;
+    this.selectedRGB = `${rgb.red} ${rgb.green} ${rgb.blue}`;
   }
 }

--- a/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.ts
+++ b/src/app/screens/image-color-picker/components/image-color-picker/image-color-picker.component.ts
@@ -9,6 +9,7 @@ import { CommonService } from '../../../../services/common.service';
 })
 export class ImageColorPickerComponent implements OnInit, OnDestroy {
   isLight = true;
+  public selectedRGB: RGB = { red: 0, green: 0, blue: 0 };
   private subscription!: Subscription;
 
   constructor(private commonService: CommonService) {}
@@ -23,5 +24,10 @@ export class ImageColorPickerComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.subscription.unsubscribe();
+  }
+
+  onReceiveSelectedColorEvent($eventSelectRGB: RGB) {
+    console.log('レシーブ！');
+    this.selectedRGB = $eventSelectRGB;
   }
 }

--- a/src/app/screens/image-color-picker/components/image-display/image-display.component.html
+++ b/src/app/screens/image-color-picker/components/image-display/image-display.component.html
@@ -1,12 +1,5 @@
 <mat-card id="image-display-card" fxLayout="column">
-    <!-- <mat-card-content>
-    </mat-card-content> -->
-
-    <mat-card-content fxLayoutAlign="center center" fxFlex="90">
+    <mat-card-content fxLayoutAlign="center center">
       <canvas id="image-canvas" fxFill></canvas>
     </mat-card-content>
-
-    <!-- <mat-card-content fxLayoutAlign="center center">
-      <p>何かしらを表示するエリア何かしらを表示するエリア何かしらを表示するエリア何かしらを表示するエリア何かしらを表示するエリア</p>
-    </mat-card-content> -->
 </mat-card>

--- a/src/app/screens/image-color-picker/components/image-display/image-display.component.scss
+++ b/src/app/screens/image-color-picker/components/image-display/image-display.component.scss
@@ -1,5 +1,4 @@
 #image-display-card {
-  width: 90%;
   height: auto;
 }
 

--- a/src/app/screens/image-color-picker/components/image-display/image-display.component.ts
+++ b/src/app/screens/image-color-picker/components/image-display/image-display.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, AfterViewInit } from '@angular/core';
+import { Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'app-image-display',
@@ -6,6 +7,7 @@ import { Component, OnInit, AfterViewInit } from '@angular/core';
   styleUrls: ['./image-display.component.scss'],
 })
 export class ImageDisplayComponent implements OnInit, AfterViewInit {
+  @Output() eventSelectRGB = new EventEmitter<RGB>();
   private canvas?: HTMLCanvasElement;
 
   constructor() {}
@@ -58,22 +60,18 @@ export class ImageDisplayComponent implements OnInit, AfterViewInit {
 
     this.canvas.onclick = (evt: MouseEvent) => {
       const color = this.extractColor(context, evt);
-      const obj = document.getElementById('click');
-      if (obj != null) {
-        obj.innerText = `rgb(${color.red}, ${color.green}, ${color.blue})`;
-      }
+      this.eventSelectRGB.emit(color);
     };
 
     this.canvas.onmousemove = (evt: MouseEvent) => {
       const color = this.extractColor(context, evt);
-      const obj = document.getElementById('move');
-      if (obj != null) {
-        obj.innerText = `rgb(${color.red}, ${color.green}, ${color.blue})`;
-      }
     };
   }
 
-  extractColor(context: CanvasRenderingContext2D, evt: MouseEvent): Color {
+  private extractColor(
+    context: CanvasRenderingContext2D,
+    evt: MouseEvent
+  ): RGB {
     const imagedata = context.getImageData(evt.offsetX, evt.offsetY, 1, 1);
     return {
       red: imagedata.data[0],

--- a/src/app/screens/image-color-picker/components/image-display/image-display.component.ts
+++ b/src/app/screens/image-color-picker/components/image-display/image-display.component.ts
@@ -8,6 +8,7 @@ import { Output, EventEmitter } from '@angular/core';
 })
 export class ImageDisplayComponent implements OnInit, AfterViewInit {
   @Output() eventSelectRGB = new EventEmitter<RGB>();
+  @Output() eventPointerRGB = new EventEmitter<RGB>();
   private canvas?: HTMLCanvasElement;
 
   constructor() {}
@@ -65,6 +66,7 @@ export class ImageDisplayComponent implements OnInit, AfterViewInit {
 
     this.canvas.onmousemove = (evt: MouseEvent) => {
       const color = this.extractColor(context, evt);
+      this.eventPointerRGB.emit(color);
     };
   }
 

--- a/src/app/screens/image-color-picker/components/picked-color/picked-color.component.html
+++ b/src/app/screens/image-color-picker/components/picked-color/picked-color.component.html
@@ -1,0 +1,1 @@
+<p>picked-color works!</p>

--- a/src/app/screens/image-color-picker/components/picked-color/picked-color.component.html
+++ b/src/app/screens/image-color-picker/components/picked-color/picked-color.component.html
@@ -2,15 +2,15 @@
   <mat-card-content fxLayout="column" fxLayoutAlign="center center">
     <p class="title">Selected</p>
     <button mat-stroked-button>RGB: {{ selectedRGB }}</button>
-    <button mat-stroked-button class="color-button">HEX: #2596be</button>
+    <button mat-stroked-button class="color-button">HEX: {{ selectedHEX }}</button>
     <button mat-stroked-button class="color-button">CMYK: 0 0 0 0</button>
     <div class="color-display"></div>
   </mat-card-content>
 
   <mat-card-content fxLayout="column" fxLayoutAlign="center center">
     <p class="title">Current Point</p>
-    <button mat-stroked-button>RGB: 0 0 0</button>
-    <button mat-stroked-button class="color-button">HEX: #2596be</button>
+    <button mat-stroked-button>RGB: 255 255 255</button>
+    <button mat-stroked-button class="color-button">HEX: #FFFFFF</button>
     <button mat-stroked-button class="color-button">CMYK: 0 0 0 0</button>
     <div class="color-display"></div>
   </mat-card-content>

--- a/src/app/screens/image-color-picker/components/picked-color/picked-color.component.html
+++ b/src/app/screens/image-color-picker/components/picked-color/picked-color.component.html
@@ -1,1 +1,17 @@
-<p>picked-color works!</p>
+<mat-card id="picked-color-card">
+  <mat-card-content fxLayout="column" fxLayoutAlign="center center">
+    <p class="title">Selected</p>
+    <button mat-stroked-button>RGB: 0 0 0</button>
+    <button mat-stroked-button class="color-button">HEX: #2596be</button>
+    <button mat-stroked-button class="color-button">CMYK: 0 0 0 0</button>
+    <div class="color-display"></div>
+  </mat-card-content>
+
+  <mat-card-content fxLayout="column" fxLayoutAlign="center center">
+    <p class="title">Current Point</p>
+    <button mat-stroked-button>RGB: 0 0 0</button>
+    <button mat-stroked-button class="color-button">HEX: #2596be</button>
+    <button mat-stroked-button class="color-button">CMYK: 0 0 0 0</button>
+    <div class="color-display"></div>
+  </mat-card-content>
+</mat-card>

--- a/src/app/screens/image-color-picker/components/picked-color/picked-color.component.html
+++ b/src/app/screens/image-color-picker/components/picked-color/picked-color.component.html
@@ -1,7 +1,7 @@
 <mat-card id="picked-color-card">
   <mat-card-content fxLayout="column" fxLayoutAlign="center center">
     <p class="title">Selected</p>
-    <button mat-stroked-button>RGB: 0 0 0</button>
+    <button mat-stroked-button>RGB: {{ selectedRGB }}</button>
     <button mat-stroked-button class="color-button">HEX: #2596be</button>
     <button mat-stroked-button class="color-button">CMYK: 0 0 0 0</button>
     <div class="color-display"></div>

--- a/src/app/screens/image-color-picker/components/picked-color/picked-color.component.html
+++ b/src/app/screens/image-color-picker/components/picked-color/picked-color.component.html
@@ -4,14 +4,14 @@
     <button mat-stroked-button>RGB: {{ selectedRGB }}</button>
     <button mat-stroked-button class="color-button">HEX: {{ selectedHEX }}</button>
     <button mat-stroked-button class="color-button">CMYK: 0 0 0 0</button>
-    <div class="color-display"></div>
+    <div class="color-display" id="selected-color-display"></div>
   </mat-card-content>
 
   <mat-card-content fxLayout="column" fxLayoutAlign="center center">
     <p class="title">Current Point</p>
-    <button mat-stroked-button>RGB: 255 255 255</button>
-    <button mat-stroked-button class="color-button">HEX: #FFFFFF</button>
+    <button mat-stroked-button>RGB: {{ pointerRGB }}</button>
+    <button mat-stroked-button class="color-button">HEX: {{ pointerHEX }}</button>
     <button mat-stroked-button class="color-button">CMYK: 0 0 0 0</button>
-    <div class="color-display"></div>
+    <div class="color-display" id="picker-color-display"></div>
   </mat-card-content>
 </mat-card>

--- a/src/app/screens/image-color-picker/components/picked-color/picked-color.component.scss
+++ b/src/app/screens/image-color-picker/components/picked-color/picked-color.component.scss
@@ -1,0 +1,25 @@
+#picked-color-card {
+
+}
+
+.title {
+  font-size: medium;
+  font-weight: bold;
+}
+
+.color-button {
+  margin-top: 5px;
+}
+
+#selected-color {
+  background-color: red;
+}
+
+.color-display {
+  height: 30px;
+  width: 70%;
+  margin-top: 5px;
+  background-color: red;
+  box-shadow: 0 5px 15px 0 rgba(0, 0, 0, .5);
+  border-radius: 5px;
+}

--- a/src/app/screens/image-color-picker/components/picked-color/picked-color.component.scss
+++ b/src/app/screens/image-color-picker/components/picked-color/picked-color.component.scss
@@ -19,7 +19,7 @@
   height: 30px;
   width: 70%;
   margin-top: 5px;
-  background-color: red;
+  background-color: white;
   box-shadow: 0 5px 15px 0 rgba(0, 0, 0, .5);
   border-radius: 5px;
 }

--- a/src/app/screens/image-color-picker/components/picked-color/picked-color.component.ts
+++ b/src/app/screens/image-color-picker/components/picked-color/picked-color.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-picked-color',
+  templateUrl: './picked-color.component.html',
+  styleUrls: ['./picked-color.component.scss'],
+})
+export class PickedColorComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/screens/image-color-picker/components/picked-color/picked-color.component.ts
+++ b/src/app/screens/image-color-picker/components/picked-color/picked-color.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Input } from '@angular/core';
 
 @Component({
   selector: 'app-picked-color',
@@ -6,6 +7,8 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./picked-color.component.scss'],
 })
 export class PickedColorComponent implements OnInit {
+  @Input() selectedRGB = '0 0 0';
+
   constructor() {}
 
   ngOnInit(): void {}

--- a/src/app/screens/image-color-picker/components/picked-color/picked-color.component.ts
+++ b/src/app/screens/image-color-picker/components/picked-color/picked-color.component.ts
@@ -7,9 +7,36 @@ import { Input } from '@angular/core';
   styleUrls: ['./picked-color.component.scss'],
 })
 export class PickedColorComponent implements OnInit {
-  @Input() selectedRGB = '0 0 0';
+  selectedRGB = '0 0 0';
+  selectedHEX = '#FFFFFF';
 
   constructor() {}
 
   ngOnInit(): void {}
+
+  @Input() set setSelectedRGB(value: string) {
+    this.selectedRGB = value;
+    const rgbArray = value.split(' ');
+    this.selectedHEX = this.convertRgbToHex(
+      rgbArray[0],
+      rgbArray[1],
+      rgbArray[2]
+    );
+  }
+
+  // TODO: 以下メソッド別ファイルに移植する
+
+  convertRgbToHex(red: string, green: string, blue: string) {
+    return (
+      '#' +
+      this.toHex(Number(red)) +
+      this.toHex(Number(green)) +
+      this.toHex(Number(blue))
+    );
+  }
+
+  toHex(color: number) {
+    const hex = color.toString(16);
+    return hex.length === 1 ? '0' + hex : hex;
+  }
 }

--- a/src/app/screens/image-color-picker/components/picked-color/picked-color.component.ts
+++ b/src/app/screens/image-color-picker/components/picked-color/picked-color.component.ts
@@ -9,6 +9,8 @@ import { Input } from '@angular/core';
 export class PickedColorComponent implements OnInit {
   selectedRGB = '0 0 0';
   selectedHEX = '#FFFFFF';
+  pointerRGB = '0 0 0';
+  pointerHEX = '#FFFFFF';
 
   constructor() {}
 
@@ -22,6 +24,26 @@ export class PickedColorComponent implements OnInit {
       rgbArray[1],
       rgbArray[2]
     );
+    const selectedColorDisplay = document.getElementById(
+      'selected-color-display'
+    );
+    if (selectedColorDisplay) {
+      selectedColorDisplay.style.backgroundColor = this.selectedHEX;
+    }
+  }
+
+  @Input() set setPointerRGB(value: string) {
+    this.pointerRGB = value;
+    const rgbArray = value.split(' ');
+    this.pointerHEX = this.convertRgbToHex(
+      rgbArray[0],
+      rgbArray[1],
+      rgbArray[2]
+    );
+    const pickerColorDisplay = document.getElementById('picker-color-display');
+    if (pickerColorDisplay) {
+      pickerColorDisplay.style.backgroundColor = this.pointerHEX;
+    }
   }
 
   // TODO: 以下メソッド別ファイルに移植する

--- a/src/app/screens/image-color-picker/image-color-picker.module.ts
+++ b/src/app/screens/image-color-picker/image-color-picker.module.ts
@@ -6,11 +6,16 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 
 import { ImageColorPickerComponent } from './components/image-color-picker/image-color-picker.component';
 import { ImageDisplayComponent } from './components/image-display/image-display.component';
+import { PickedColorComponent } from './components/picked-color/picked-color.component';
 
 const routes: Routes = [{ path: '', component: ImageColorPickerComponent }];
 
 @NgModule({
-  declarations: [ImageColorPickerComponent, ImageDisplayComponent],
+  declarations: [
+    ImageColorPickerComponent,
+    ImageDisplayComponent,
+    PickedColorComponent,
+  ],
   imports: [
     RouterModule.forChild(routes),
     CommonModule,


### PR DESCRIPTION
## やったこと
- `選択` `マウスオーバー箇所` 色情報表示エリア実装
   - `picked-color-component` 作成
   - RGB -> HEX 変換実装 https://github.com/tineapedis/image-color-picker/pull/6/commits/253c10490d3a806d32d9476fd60014f0347c693c

## やらないこと
- `CMYK` 表示

## 備考
### 参考
- コンポーネント間のデータの受け渡し
   - https://qiita.com/ksh-fthr/items/db6a48d072d5e9a33f0b
   - https://dev.classmethod.jp/articles/angular-input-output/  
- RGB to HEX
   - https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb 

## スクリーンショット
| light | dark |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/27864195/113590567-cb385380-966d-11eb-8291-05b49bcd781e.png" width="350"> | <img src="https://user-images.githubusercontent.com/27864195/113590401-90ceb680-966d-11eb-85bc-8548557624c3.png" width="350"> |
